### PR TITLE
Change in MQTT connection clientId: GatewayHid insted of random clientid

### DIFF
--- a/acnsdk/src/main/java/com/arrow/acn/api/mqtt/AbstractMqttAcnApiService.java
+++ b/acnsdk/src/main/java/com/arrow/acn/api/mqtt/AbstractMqttAcnApiService.java
@@ -213,7 +213,7 @@ public abstract class AbstractMqttAcnApiService extends AbstractTelemetrySenderS
     }
 
     protected String getClientId() {
-        return MqttClient.generateClientId();
+        return mGatewayId;
     }
 
     @NonNull


### PR DESCRIPTION
As per mentioned by Tam, Petnet project which has some requirement that our SDK needs to connect to AC cloud with ClientID = GatewayHID.